### PR TITLE
Strip namespaces from each trx file before processing

### DIFF
--- a/src/dotnet-trx-merge/Services/TrxFetcher.cs
+++ b/src/dotnet-trx-merge/Services/TrxFetcher.cs
@@ -24,6 +24,18 @@ public class TrxFetcher : ITrxFetcher
         foreach (var trxFile in filesToMerge)
         {
             var trxDocument = XDocument.Load(trxFile);
+                        
+            // Strip namespaces from the document; if we don't do this, and the input .trx files have namespaces, no descendants will be found
+            // and an empty output file will be generated.
+            // https://stackoverflow.com/a/14865785/84898
+            foreach (var xe in trxDocument.Elements().DescendantsAndSelf())
+            {
+                // Stripping the namespace by setting the name of the element to its localname only
+                xe.Name = xe.Name.LocalName;
+                // replacing all attributes with attributes that are not namespaces and their names are set to only the localname
+                xe.ReplaceAttributes((from xattrib in xe.Attributes().Where(xa => !xa.IsNamespaceDeclaration) select new XAttribute(xattrib.Name.LocalName, xattrib.Value)));
+            }
+            
             var results = trxDocument.Descendants("UnitTestResult");
             var definitions = trxDocument.Descendants("UnitTest");
             var entries = trxDocument.Descendants("TestEntry");


### PR DESCRIPTION
My .trx files had namespaces which was causing the tool to fail. The patch just removes the namespaces before processing.