### PR TITLE
Set default for runUser if its not found

### DIFF
--- a/src/dotnet-trx-merge/Services/TrxFetcher.cs
+++ b/src/dotnet-trx-merge/Services/TrxFetcher.cs
@@ -27,12 +27,22 @@ public class TrxFetcher : ITrxFetcher
         TestTimes testTimes = new TestTimes();
         foreach (var trxFile in filesToMerge)
         {
+            _log.Debug($"Processing file {trxFile}");
             var trxDocument = XDocument.Load(trxFile);
             XElement? rootElement = trxDocument.Root;
             if (rootElement == null)
                 throw new Exception($"Could not find root element in file {trxFile}");
             ns = rootElement.GetDefaultNamespace();
-            runUser ??= rootElement.Attribute("runUser")!.Value;
+            var runUserElement = rootElement.Attribute("runUser");
+            if (runUserElement != null)
+            {
+                runUser ??= runUserElement.Value;
+            } else
+            {
+                _log.Warning($"Could not find runUser attribute in file {trxFile}. Defaulting to UnknownRunUser");
+                runUser = "UnknownRunUser";
+            }
+            
             testTimes.AddTestTimes(rootElement.Descendants(ns+"Times").FirstOrDefault());
             var results = trxDocument.Descendants(ns + "UnitTestResult");
             var definitions = trxDocument.Descendants(ns + "UnitTest");

--- a/test/dotnet-trx-merge.UnitTests/Commands/MergeCommandTests.cs
+++ b/test/dotnet-trx-merge.UnitTests/Commands/MergeCommandTests.cs
@@ -50,7 +50,7 @@ public class MergeCommandTests
         command.Run();
 
         // Assert
-        trxFetcher.Received(1).AddLatestTests(Arg.Is<string[]>(files => files.Count() == 12));
+        trxFetcher.Received(1).AddLatestTests(Arg.Is<string[]>(files => files.Count() == 13));
     }
     
     [Fact]

--- a/test/dotnet-trx-merge.UnitTests/Fixtures/Merge/TrxWithNoRunUser.trx
+++ b/test/dotnet-trx-merge.UnitTests/Fixtures/Merge/TrxWithNoRunUser.trx
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TestRun id="4fbfe72b-df6b-413e-bb31-d2f6389884ef" name="Utilizador@COMPUTER 2023-08-29 18:35:26">
+  <Times creation="2023-08-29T18:35:26.3589967+01:00" queuing="2023-08-29T18:35:26.3589971+01:00" start="2023-08-29T18:35:25.5259659+01:00" finish="2023-08-29T18:35:26.3652254+01:00" />
+  <TestSettings name="default" id="47f006f1-174a-40fe-8dd3-78256e22bccf">
+    <Deployment runDeploymentRoot="Utilizador_COMPUTER_2023-08-29_18_35_26" />
+  </TestSettings>
+  <Results>
+    <UnitTestResult executionId="e68ff2c7-8309-483b-a1fd-414967943cf0" testId="86e2b6e4-df7a-e4fa-006e-c056c908e219" testName="SecondSimpleNumberCompare" computerName="COMPUTER" duration="00:00:00.0081300" startTime="2023-08-29T18:35:26.2207424+01:00" endTime="2023-08-29T18:35:26.2287977+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e68ff2c7-8309-483b-a1fd-414967943cf0" />
+  </Results>
+  <TestDefinitions>
+    <UnitTest name="SecondSimpleNumberCompare" storage="c:\users\utilizador\appdata\local\temp\f7efe9c2\nunittestpassonsecondrunexample\bin\debug\net6.0\nunittestpassonsecondrunexample.dll" id="86e2b6e4-df7a-e4fa-006e-c056c908e219">
+      <Execution id="e68ff2c7-8309-483b-a1fd-414967943cf0" />
+      <TestMethod codeBase="C:\Users\Utilizador\AppData\Local\Temp\F7EFE9C2\NUnitTestPassOnSecondRunExample\bin\Debug\net6.0\NUnitTestPassOnSecondRunExample.dll" adapterTypeName="executor://nunit3testexecutor/" className="NUnitTestExample.Tests" name="SecondSimpleNumberCompare" />
+    </UnitTest>
+  </TestDefinitions>
+  <TestEntries>
+    <TestEntry testId="86e2b6e4-df7a-e4fa-006e-c056c908e219" executionId="e68ff2c7-8309-483b-a1fd-414967943cf0" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+  </TestEntries>
+  <TestLists>
+    <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
+  </TestLists>
+  <ResultSummary outcome="Completed">
+    <Counters total="1" executed="1" passed="1" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    <Output>
+      <StdOut>NUnit Adapter 4.2.0.0: Test execution started
+Running selected tests in C:\Users\Utilizador\AppData\Local\Temp\F7EFE9C2\NUnitTestPassOnSecondRunExample\bin\Debug\net6.0\NUnitTestPassOnSecondRunExample.dll
+   NUnit3TestExecutor discovered 1 of 1 NUnit test cases using Current Discovery mode, Non-Explicit run
+NUnit Adapter 4.2.0.0: Test execution complete
+</StdOut>
+    </Output>
+  </ResultSummary>
+</TestRun>

--- a/test/dotnet-trx-merge.UnitTests/Services/TrxFetcherTests.cs
+++ b/test/dotnet-trx-merge.UnitTests/Services/TrxFetcherTests.cs
@@ -9,6 +9,7 @@ namespace dotnet_test_rerun.UnitTests.Services;
 
 public class TrxFetcherTests
 {
+    private const string TrxWithNoRunUser = "../../../Fixtures/Merge/TrxWithNoRunUser.trx";
     private const string TrxAllPass = "../../../Fixtures/Merge/TrxAllPass.trx";
     private const string TrxWithFailures = "../../../Fixtures/Merge/TrxWithFailures.trx";
     private const string TrxWithErrors = "../../../Fixtures/Merge/TrxWithErrors.trx";
@@ -691,6 +692,46 @@ public class TrxFetcherTests
             "3dacbae9-707e-1881-d63c-3573123dffc6");
         
         ValidateOutcome(mergedDocument, 2, 2, 0, "Completed");
+    }
+
+    [Fact]
+    public void AddLatestTests_WithOneFileWithNoRunUser_AllPass()
+    {
+        // Arrange
+        var logger = new Logger();
+        var trxFetcher = new TrxFetcher(logger);
+
+        // Act
+        var mergedDocument = trxFetcher.AddLatestTests(new[] { TrxWithNoRunUser });
+
+        // Assert
+        var results = mergedDocument.Descendants("UnitTestResult");
+        results.Should().HaveCount(1);
+        ValidateTestResult(results.ElementAt(0),
+            "e68ff2c7-8309-483b-a1fd-414967943cf0",
+            "86e2b6e4-df7a-e4fa-006e-c056c908e219",
+            "SecondSimpleNumberCompare",
+            "Passed");
+
+        var definitions = mergedDocument.Descendants("UnitTest");
+        definitions.Should().HaveCount(1);
+        ValidateTestDefinition(definitions.ElementAt(0),
+            "e68ff2c7-8309-483b-a1fd-414967943cf0",
+            "86e2b6e4-df7a-e4fa-006e-c056c908e219",
+            "SecondSimpleNumberCompare");
+
+        var entries = mergedDocument.Descendants("TestEntry");
+        entries.Should().HaveCount(1);
+        ValidateTestEntry(entries.ElementAt(0),
+            "e68ff2c7-8309-483b-a1fd-414967943cf0",
+            "86e2b6e4-df7a-e4fa-006e-c056c908e219");
+
+        ValidateOutcome(mergedDocument, 1, 1, 0, "Completed");
+        ValidateTimes(mergedDocument.Descendants("Times").First(),
+            "2023-08-29T18:35:26.3589967+01:00",
+            "2023-08-29T18:35:26.3589971+01:00",
+            "2023-08-29T18:35:25.5259659+01:00",
+            "2023-08-29T18:35:26.3652254+01:00");
     }
 
     private void ValidateTimes(XElement times, string creation, string queued, string start, string finish)


### PR DESCRIPTION
## Context
This fixes issue 97 where a missing runUser in the trx file causes a NRE

## Description
Defaults the run user if it doesn't exist to UnknownRunUser

## Changes in the codebase
Defaults the run user if it doesn't exist to UnknownRunUser
Adds logging to indicate that a trx file is being processed to help with diagnotics

## Associated Issues
#97 